### PR TITLE
Improve flexbox for sponsors logos

### DIFF
--- a/web/index.md
+++ b/web/index.md
@@ -256,88 +256,90 @@ This event is supported by:
 
 
 <style>
+
 .row {
-  display: -ms-flexbox; /* IE10 */
   display: flex;
-  -ms-flex-wrap: wrap; /* IE10 */
   flex-wrap: wrap;
-  padding: 0 4px;
+  justify-content: space-evenly;
+  align-items: center;
+  gap: 1em;
 }
 
-/* Create four equal columns that sits next to each other */
+/* Create three equal columns that sits next to each other */
 .column {
-  -ms-flex: 25%; /* IE10 */
-  flex: 25%;
-  max-width: 25%;
-  padding: 0 4px;
+  width: 30%;
 }
 
 .column img {
-  margin-top: 8px;
-  vertical-align: middle;
   width: 100%;
 }
 
 /* Responsive layout - makes a two column-layout instead of four columns */
 @media screen and (max-width: 800px) {
   .column {
-    -ms-flex: 50%;
-    flex: 50%;
-    max-width: 50%;
+    flex: 48%;
   }
 }
 
-/* Responsive layout - makes the two columns stack on top of each other instead of next to each other */
+/* Responsive layout - makes single column-layout */
 @media screen and (max-width: 600px) {
+  .row {
+    gap: 2em;
+  }
   .column {
-    -ms-flex: 100%;
     flex: 100%;
-    max-width: 100%;
+    padding: 0 10%;
   }
 }
 </style>
 
 
 <div class="row">
-    <div class="column">
-        <a href="https://ethz.ch"><img style="width: 100%" src="images/sponsors/ethz.png"/></a>
-    </div>
-    <div class="column" >
-        <a href="https://www.agroscope.admin.ch"><img style="width: 100%" src="images/sponsors/agroscope.jpg"/></a>
-    </div>
-    <div class="column">
-        <a href="https://www.snf.ch"><img style="width: 100%" src="images/sponsors/snf.png"/></a>
-    </div>
+  <div class="column">
+    <a href="https://ethz.ch">
+    <img src="images/sponsors/ethz.png"/>
+    </a>
+  </div>
+  <div class="column" >
+    <a href="https://www.agroscope.admin.ch">
+    <img src="images/sponsors/agroscope.jpg"/>
+    </a>
+  </div>
+  <div class="column">
+    <a href="https://www.snf.ch">
+    <img src="images/sponsors/snf.png"/>
+    </a>
+  </div>
+
+  <div class="column">
+    <a href="https://curvenote.com/oxa:Iv0z5HLWzgC0LDigFNc1/hYC59pUXsouqA6e2RiOI.1">
+    <img src="images/sponsors/ssi-logo.png"/>
+    </a>
+  </div>
+  <div class="column">
+    <a href="https://www.iris-instruments.com/">
+    <img src="images/sponsors/iris-logo.png"/>
+    </a>
+  </div>
+  <div class="column">
+    <a href="https://www.medusa-radiometrics.com/">
+    <img src="images/sponsors/Medusa_WebLogo_rectangle-1.png"/>
+    </a>
+  </div>
+
+  <div class="column">
+    <a href="https://www.allied-germany.de/">
+    <img src="images/sponsors/allied-associates.png"/>
+    </a>
+  </div>
+  <div class="column">
+    <a href="https://geoprospectors.com/en/">
+    <img src="images/sponsors/Geoprospectors_Logo_4c_neu.png"/>
+    </a>
+  </div>
+  <div class="column">
+    <a href="https://curvenote.com/">
+    <img src="images/sponsors/logo-text-blue.svg"/>
+    </a>
+  </div>
 </div>
-	
-<div class="row"> 
-	<a href="https://curvenote.com/oxa:Iv0z5HLWzgC0LDigFNc1/hYC59pUXsouqA6e2RiOI.1"><img style="width: 100%" src="images/sponsors/ssi-logo.png"/></a>
-</div>
-
-<div class="row"> 
-	<a href="https://www.iris-instruments.com/"><img style="width: 100%" src="images/sponsors/iris-logo.png"/></a>	
-	
-</div>
-<div class="row"> 
-	<a href="https://www.medusa-radiometrics.com/"><img style="width: 100%" src="images/sponsors/Medusa_WebLogo_rectangle-1.png"/></a>	
-	
-</div>
-<div class="row"> 
-	<a href="https://www.allied-germany.de/"><img style="width: 100%" src="images/sponsors/allied-associates.png"/></a>	
-	
-</div>
-<div class="row"> 
-	<a href="https://geoprospectors.com/en/"><img style="width: 100%" src="images/sponsors/Geoprospectors_Logo_4c_neu.png"/></a>	
-	
-</div>
-<div class="row"> 
-	<a href="https://curvenote.com/"><img style="width: 100%" src="images/sponsors/logo-text-blue.svg"/></a>	
-	
-</div>
-
-
-
-
-
-
-


### PR DESCRIPTION
Hi everyone! I'm Santiago Soler, one of the instructors that will participate in the SimPEG tutorial. First of all, thanks again for the invitation, and congrats for the website you created.

I'm opening this PR to improve the flexbox layout you created for the sponsors. With this change, sponsors images are shown in 3 columns for large screens, in 2 columns for smaller screens (up to 800px of width), and a single column for the smallest screens (up to 600px of width).

Hope you like it! I'm looking forward to meet you all in person!

BTW, I loved to see that you used Nēnē for the website. I'm sure @leouieda will be happy to see it.